### PR TITLE
Update GOPATH setting.

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -124,8 +124,18 @@ fi
 
 # Golang
 if hash go 2>/dev/null; then
-    export GOPATH=$HOME/goprojects
-    export PATH=$PATH:$GOPATH/bin
+    GO_CACHE=$HOME/.gopath/cache # First GOPATH, 'go get' saves files here, and it's always safe to be cleaned
+    GO_PKGS=$HOME/.gopath/pkgs   # For 3rd party go packages, use 'gosave' to sync all packages from cache to this folder or moved manually
+    GO_PROJ=$HOME/goprojects     # Your go projects root
+    export GOPATH=$GO_CACHE:$GO_PKGS:$GO_PROJ
+    export PATH=$PATH:$GO_CACHE/bin:$GO_PKGS/bin:$GO_PROJ/bin
+    alias gosave='rsync -aAXv ${GO_CACHE}/ ${GO_PKGS}'
+    #                    |||└─ increase verbosity
+    #                    ||└─ preserve extended attributes
+    #                    |└─ preserve ACLs (implies --perms)
+    #                    └─ archive mode; equals -rlptgoD (no -H,-A,-X)
+    alias goclean='[ -d "$GO_CACHE" ] && rm -rf ${GO_CACHE}/*'
+    #                                                       └─ double rm verification in zsh
 fi
 
 # aliases


### PR DESCRIPTION
Change to 3 level GOPATHs. Though seems Golang suggest to use only 1 GOPATH.

The first one is a landing workspace. Since it's listed first, whenever use `go get` any new package, it always ends up in this workspace. And make it a rule to never do any development in there, so it's always completely safe to clean this folder whenever it gets too large (with Go packages don't use). After all, it only has Go packages that can get again with go get. It make easier to `undo` a `go get`.

The second workspace is for all "favorite" 3rd party packages. Regularly used packages should moved from first workspace into it.

The third workspace is Go packages works on, and their dependencies. It's convenient to have working packages separate from all 3rd parties, so they don't get in each other's way.